### PR TITLE
Miscellaneous build fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    name: Build
+    strategy:
+      matrix:
+        tts: [espeak, espeak-ng, speech-dispatcher]
+    steps:
+      - name: System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autopoint \
+            doxygen  \
+            libespeak-dev \
+            libespeak-ng-dev \
+            libpng-dev \
+            librsvg2-dev \
+            libsdl-image1.2-dev \
+            libsdl-mixer1.2-dev \
+            libsdl-net1.2-dev \
+            libsdl-pango-dev \
+            libspeechd-dev \
+            libxml2-dev
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          autoreconf -i
+          # Disable all, enable just the
+          ./configure --without-espeak --without-espeak-ng --without-speech-dispatcher --with-${{ matrix.tts }}
+          # TODO: wire up src/tests to main build system
+          make check

--- a/configure.ac
+++ b/configure.ac
@@ -271,8 +271,9 @@ AC_CHECK_LIB([m],
 	[AC_MSG_ERROR([Math library not found - functions in <math.h> may not be available.])])
 
 
-dnl One or other of espeak or speech-dispatcher is required
+dnl One of espeak, espeak-ng, or speech-dispatcher is required
 AC_ARG_WITH([espeak],[AS_HELP_STRING([--without-espeak], [Do not use espeak even if available])])
+AC_ARG_WITH([espeak-ng],[AS_HELP_STRING([--without-espeak-ng], [Do not use espeak-ng even if available])])
 AC_ARG_WITH([speech-dispatcher],[AS_HELP_STRING([--without-speech-dispatcher], [Do not use speech-dispatcher even if available])])
 
 AS_IF([test "x$with_espeak" != "xno"],
@@ -283,19 +284,29 @@ AS_IF([test "x$with_espeak" != "xno"],
 		 have_espeak=yes],
 		[have_espeak=no])])
 
+AS_IF([test "x$with_espeak_ng" != "xno"],
+	[PKG_CHECK_MODULES([ESPEAK_NG_TTS],
+		 [espeak-ng],
+		 [have_espeak_ng=yes],
+		 [have_espeak_ng=no])])
+
 AS_IF([test "x$with_speech_dispatcher" != "xno"],
 	[PKG_CHECK_MODULES([SPEECHD_TTS],
 		 [speech-dispatcher],
 		 [have_speechd=yes],
 		 [have_speechd=no])])
 
-AS_IF([test "x$have_espeak" = "xyes"],  [
+AS_IF([test "x$have_espeak" = "xyes"], [
        TTS_CFLAGS="$ESPEAK_TTS_CFLAGS" TTS_LIBS="$ESPEAK_TTS_LIBS"
        AC_DEFINE([WITH_ESPEAK],[1],[Compile with espeak])],
+      [test "x$have_espeak_ng" = "xyes"], [
+       TTS_CFLAGS="$ESPEAK_NG_TTS_CFLAGS" TTS_LIBS="$ESPEAK_NG_TTS_LIBS"
+       AC_DEFINE([WITH_ESPEAK],[1],[Compile with espeak])
+       AC_DEFINE([WITH_ESPEAK_NG],[1],[Use espeak-ng fork])],
       [test "x$have_speechd" = "xyes"], [
        TTS_CFLAGS="$SPEECHD_TTS_CFLAGS" TTS_LIBS="$SPEECHD_TTS_LIBS"
        AC_DEFINE([WITH_ESPEAK],[0],[Compile with espeak])],
-      AC_MSG_ERROR([Neither espeak nor speech-dispatcher text-to-speech library found]))
+      AC_MSG_ERROR([No text-to-speech library found]))
 
 CFLAGS="$CFLAGS $TTS_CFLAGS"
 LIBS="$LIBS $TTS_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -271,52 +271,34 @@ AC_CHECK_LIB([m],
 	[AC_MSG_ERROR([Math library not found - functions in <math.h> may not be available.])])
 
 
+dnl One or other of espeak or speech-dispatcher is required
+AC_ARG_WITH([espeak],[AS_HELP_STRING([--without-espeak], [Do not use espeak even if available])])
+AC_ARG_WITH([speech-dispatcher],[AS_HELP_STRING([--without-speech-dispatcher], [Do not use speech-dispatcher even if available])])
 
+AS_IF([test "x$with_espeak" != "xno"],
+	[AC_CHECK_LIB([espeak],
+		[espeak_Cancel],
+		[ESPEAK_TTS_CFLAGS="-I/usr/include/espeak/"
+		 ESPEAK_TTS_LIBS="-lespeak"
+		 have_espeak=yes],
+		[have_espeak=no])])
 
+AS_IF([test "x$with_speech_dispatcher" != "xno"],
+	[PKG_CHECK_MODULES([SPEECHD_TTS],
+		 [speech-dispatcher],
+		 [have_speechd=yes],
+		 [have_speechd=no])])
 
-TTS_CFLAGS=""
-AC_CHECK_LIB([espeak],
-	[espeak_Cancel],
-	[ AC_DEFINE([WITH_ESPEAK],[1],[Compile with espeak]) ESPEAK_TTS_CFLAGS=" -I/usr/include/espeak/ -lespeak" TTS_CFLAGS=" -I/usr/include/espeak/ -lespeak"],
-	[],[])
+AS_IF([test "x$have_espeak" = "xyes"],  [
+       TTS_CFLAGS="$ESPEAK_TTS_CFLAGS" TTS_LIBS="$ESPEAK_TTS_LIBS"
+       AC_DEFINE([WITH_ESPEAK],[1],[Compile with espeak])],
+      [test "x$have_speechd" = "xyes"], [
+       TTS_CFLAGS="$SPEECHD_TTS_CFLAGS" TTS_LIBS="$SPEECHD_TTS_LIBS"
+       AC_DEFINE([WITH_ESPEAK],[0],[Compile with espeak])],
+      AC_MSG_ERROR([Neither espeak nor speech-dispatcher text-to-speech library found]))
 
-AC_CHECK_LIB([speechd],
-	[spd_say],
-	[ AC_DEFINE([WITH_ESPEAK],[0],[Compile with espeak]) SPEECHD_TTS_CFLAGS=" -I/usr/include/speech-dispatcher -lspeechd" TTS_CFLAGS=" -lspeechd"],
-	[],[])
-
-
-
-
-if test -z "$TTS_CFLAGS"  ; then
-	AC_MSG_ERROR([Text To Speech development Library not found! (ESPEAK/SPEECHD) ])
-fi
-
-
-AC_ARG_WITH([speech-dispatcher],[AS_HELP_STRING([--with-speech-dispatcher])],
-[
-	if test -n "$SPEECHD_TTS_CFLAGS" ; then
-		TTS_CFLAGS="$SPEECHD_TTS_CFLAGS"
-		AC_DEFINE([WITH_ESPEAK],[0],[Compile with espeak])
-	else
-		AC_MSG_ERROR([speechd development Library not found!])
-	fi
-	
-],[])
-
-AC_ARG_WITH([espeak],[AS_HELP_STRING([--with-espeak])],
-[
-	if test -n "$ESPEAK_TTS_CFLAGS" ; then
-		TTS_CFLAGS="$ESPEAK_TTS_CFLAGS"
-		AC_DEFINE([WITH_ESPEAK],[1],[Compile with espeak])	
-	else
-		AC_MSG_ERROR([espeak development Library not found!])
-	fi
-	
-],[])
-
-AC_MSG_NOTICE([TTS CFLAGS$TTS_CFLAGS ])
 CFLAGS="$CFLAGS $TTS_CFLAGS"
+LIBS="$LIBS $TTS_LIBS"
 
 dnl Output substitutions needed for t4k_common.pc.in:
 dnl (these are used by the subsequent build process of a program using t4k_common,

--- a/src/t4k_common.h
+++ b/src/t4k_common.h
@@ -245,7 +245,7 @@ MFStrategy;
 #define MAX_LINES           128 //!< Maximum lines to wrap.
 #define MAX_LINEWIDTH       256 //!< Maximum characters of each line.
 
-extern static char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; //!< Global buffer for wrapped lines.
+extern char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; //!< Global buffer for wrapped lines.
 
 //TODO separate headers for different areas a la SDL?
 

--- a/src/t4k_globals.h
+++ b/src/t4k_globals.h
@@ -49,8 +49,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #define T4K_TOOLTIP_FONTSIZE 18
 
 //TTS Thread
-SDL_Thread *tts_thread;
-int text_to_speech_status;
+extern SDL_Thread *tts_thread;
+extern int text_to_speech_status;
 
 
 extern int debug_status;

--- a/src/t4k_linewrap.c
+++ b/src/t4k_linewrap.c
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include <stdio.h>
 
 static char wrapped_lines0[MAX_LINES][MAX_LINEWIDTH];  // for internal storage
-//char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; // publicly available!
+extern char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; // publicly available!
 
 
 

--- a/src/t4k_tts.c
+++ b/src/t4k_tts.c
@@ -30,6 +30,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #include "SDL_thread.h"
 
+SDL_Thread *tts_thread;
+int text_to_speech_status;
 
 #if WITH_ESPEAK == 1
 
@@ -91,7 +93,6 @@ int T4K_Tts_set_voice(char voice_name[]){
 
 //Stop the speech if it is speaking
 void T4K_Tts_stop(){
-	extern SDL_Thread *tts_thread;
 	if (tts_thread)
 	{
 		SDL_KillThread(tts_thread);
@@ -129,7 +130,6 @@ espeak_SetParameter(espeakPITCH,pitch,0);
  * if mode = APPEND then wait till speaking is finished 
  * then read the new text */
 void T4K_Tts_say(int rate,int pitch,int mode, const char* text, ...){
-	extern SDL_Thread *tts_thread;
 	tts_argument data_to_pass;
 	
 	
@@ -246,7 +246,6 @@ int T4K_Tts_set_voice(char voice_name[]){
 
 //Stop the speech if it is speaking
 void T4K_Tts_stop(){
-	extern SDL_Thread *tts_thread;
 	if (tts_thread)
 	{
 		SDL_KillThread(tts_thread);
@@ -291,7 +290,6 @@ void T4K_Tts_set_pitch(int pitch){
  * if mode = APPEND then wait till speaking is finished 
  * then read the new text */
 void T4K_Tts_say(int rate,int pitch,int mode, const char* text, ...){
-	extern SDL_Thread *tts_thread;
 	tts_argument data_to_pass;
 	
 	

--- a/src/t4k_tts.c
+++ b/src/t4k_tts.c
@@ -35,7 +35,12 @@ int text_to_speech_status;
 
 #if WITH_ESPEAK == 1
 
-#include <speak_lib.h>
+#if WITH_ESPEAK_NG
+# include <espeak-ng/speak_lib.h>
+#else
+# include <speak_lib.h>
+#endif
+
 /* TTS annoncement should be in thread otherwise 
  * it will freez the game till announcemrnt finishes */
 int tts_thread_func(void *arg)


### PR DESCRIPTION
Some fixes for issues found while trying to [update the Tux Typing Flatpak to a newer toolchain](https://github.com/flathub/com.tux4kids.tuxtype/pull/6).

- configure: improve espeak/speech-dispatcher checks
- linewrap: Fix declaration of wrapped_lines
- Fix multiple definition of TTS variables

Marked as draft because, while I have compiled this code, I have not actually run tuxtype or tuxmath against it.
