### PR TITLE
CMakeList.txt:fix how some defines are defined (unterminated ")

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #This script was sloppily frankensteined from a handful of tux4kids'
-#other CMakeLists.txt and is not safe for human consumption. 
+#other CMakeLists.txt and is not safe for human consumption.
 #Please hack responsibly.
 
 # TODO - add cmake build support for t4k_test program - DSB
@@ -39,10 +39,10 @@ t4k_include_directory(RSVG)
 
 set( T4K_COMMON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
 if(T4K_DEVELOPER_WARNINGS)
-    list(APPEND CMAKE_C_FLAGS -Wall) 
+    list(APPEND CMAKE_C_FLAGS -Wall)
 endif()
 
-#Declare the library as a SO 
+#Declare the library as a SO
 add_library( ${LIB_NAME} SHARED
     ${T4K_COMMON_SOURCES} ${T4K_COMMON_HEADERS} )
 
@@ -66,17 +66,21 @@ target_link_libraries(${LIB_NAME}
 
 t4k_include_definition(HAVE_LIBSDL_PANGO)
 t4k_include_definition(HAVE_LIBPNG)
-set_target_properties (${LIB_NAME} PROPERTIES 
+set_target_properties (${LIB_NAME} PROPERTIES
     COMPILE_FLAGS "${_rsvg_def} ${_pango_def} ${_rsvg_cflags} ${_cairo_cflags}"
-    COMPILE_DEFINITIONS
-    "COMMON_DATA_PREFIX=\"${DATA_PREFIX}\";USE_T4K_PREFIX=1;PACKAGE_STRING=\"${PACKAGE_NAME}\""
     LINK_INTERFACE_LIBRARIES ""
     )
+
+target_compile_definitions(${LIB_NAME} PUBLIC
+    COMMON_DATA_PREFIX=\"${DATA_PREFIX}\"
+    PACKAGE_STRING=\"${PACKAGE_NAME}\"
+    USE_T4K_PREFIX=1
+)
 
 add_dependencies(${LIB_NAME} linebreak)
 
 install( TARGETS ${LIB_NAME}
-    DESTINATION lib ) 
+    DESTINATION lib )
 install(FILES ${T4K_COMMON_SOURCE_DIR}/t4k_common.h
     ${T4K_COMMON_SOURCE_DIR}/t4k_alphasort.h
     ${T4K_COMMON_SOURCE_DIR}/t4k_scandir.h

--- a/src/linebreak/CMakeLists.txt
+++ b/src/linebreak/CMakeLists.txt
@@ -23,7 +23,7 @@ t4k_include_definition(HAVE_ICONV)
 # project.  For that reason, we need to examine whether certain settings
 # have been made before, or not.
 
-# Removed the conditional since ConfigureChecksIntl 
+# Removed the conditional since ConfigureChecksIntl
 # guards itself with INTL_CHECKS_DONE, is that okay? -BML
 include(ConfigureChecksIntl)
 t4k_gentle_set(LINEBREAK_BINARY_DIR ${CMAKE_BINARY_DIR})
@@ -42,26 +42,20 @@ add_definitions(
     -Drelocate=liblinebreak_relocate
     -DDEPENDS_ON_LIBICONV=1
     )
-    
+
 if (APPLE)
-set_directory_properties(PROPERTIES COMPILE_DEFINITIONS
-	LOCALEDIR='\"${LOCALE_DIR}\"'        	
-	LOCALE_ALIAS_PATH='\"${LOCALE_DIR}\"'
-	LIBDIR='\"${TOP_SRC_DIR}\"'
-	INSTALLDIR='\"${PREFIX}\"' 
-	)
 add_definitions(
-		-DLOCALEDIR='\"${LOCALE_DIR}\"' 
+		-DLOCALEDIR='\"${LOCALE_DIR}\"'
 		-DLOCALE_ALIAS_PATH='\"${LOCALE_DIR}\"'
 		-DLIBDIR='\"${TOP_SRC_DIR}\"'
-		-DINSTALLDIR='\"${PREFIX}\"' 
+		-DINSTALLDIR='\"${PREFIX}\"'
 		)
 else (APPLE)
 add_definitions(
-		-DLOCALEDIR=\\"${LOCALE_DIR}\\" 
-		-DLOCALE_ALIAS_PATH=\\"${LOCALE_DIR}\\"
-		-DLIBDIR=\\"${TOP_SRC_DIR}\\"
-		-DINSTALLDIR=\\"${PREFIX}\\" 
+		-DLOCALEDIR=\"${LOCALE_DIR}\"
+		-DLOCALE_ALIAS_PATH=\"${LOCALE_DIR}\"
+		-DLIBDIR=\"${TOP_SRC_DIR}\"
+		-DINSTALLDIR=\"${PREFIX}\"
 		)
 endif (APPLE)
 
@@ -69,10 +63,10 @@ file(GLOB_RECURSE LINEBREAK_HEADERS ${LINEBREAK_SOURCE_DIR} *.h)
 file(GLOB_RECURSE LINEBREAK_SOURCES ${LINEBREAK_SOURCE_DIR} *.c)
 
 include_directories(
-  ${LINEBREAK_BINARY_DIR} 
-  ${LINEBREAK_SOURCE_DIR} 
+  ${LINEBREAK_BINARY_DIR}
+  ${LINEBREAK_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR})
-  
+
 if (ICONV_FOUND)
   include_directories(${ICONV_INCLUDE_DIR})
   target_link_libraries(linebreak ${ICONV_LIBRARY})


### PR DESCRIPTION
For #1

I'm not sure if it fixes it for a Mac. Once a GitHub actions workflow
has been added, it should be relatively simple to add an osx test.

though this gets rid of some errors, it's still problematic... note that some variables are not getting set. Want me to continue with this PR and see if I can fix that?

```
cd /home/andy/src/tux4kids/t4kcommon/cmake_build/src/linebreak && /usr/bin/cc -DDEPENDS_ON_LIBICONV=1 -DENABLE_RELOCATABLE=1 -DHAVE_CONFIG_H=1 -DHAVE_ICONV=1 -DHAVE_LIBPNG=1 -DHAVE_LIBSDL_PANGO=1 -DINSTALLDIR=\"\" -DIN_LIBLINEBREAK -DIN_LIBRARY -DLIBDIR=\"\" -DLOCALEDIR=\"\" -DLOCALE_ALIAS_PATH=\"\" -DMAKE_LINEBREAK_LIB -DNO_XMALLOC -Drelocate=liblinebreak_relocate -Dset_relocation_prefix=liblinebreak_set_relocation_prefix -I/usr/include/SDL -I/usr/include/libxml2 -I/home/andy/src/tux4kids/t4kcommon/gettext -I/home/andy/src/tux4kids/t4kcommon/cmake_build -I/home/andy/src/tux4kids/t4kcommon/cmake_build/src -I/home/andy/src/tux4kids/t4kcommon/cmake_build/gettext -I/home/andy/src/tux4kids/t4kcommon/cmake_build/src/linebreak -I/home/andy/src/tux4kids/t4kcommon/src/linebreak  -MD -MT src/linebreak/CMakeFiles/linebreak.dir/linebreak.c.o -MF CMakeFiles/linebreak.dir/linebreak.c.o.d -o CMakeFiles/linebreak.dir/linebreak.c.o -c /home/andy/src/tux4kids/t4kcommon/src/linebreak/linebr
```