### PR TITLE
Fix seg fault

### DIFF
--- a/src/t4k_common.h
+++ b/src/t4k_common.h
@@ -245,7 +245,7 @@ MFStrategy;
 #define MAX_LINES           128 //!< Maximum lines to wrap.
 #define MAX_LINEWIDTH       256 //!< Maximum characters of each line.
 
-extern static char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; //!< Global buffer for wrapped lines.
+extern char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; //!< Global buffer for wrapped lines.
 
 //TODO separate headers for different areas a la SDL?
 

--- a/src/t4k_globals.h
+++ b/src/t4k_globals.h
@@ -49,8 +49,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #define T4K_TOOLTIP_FONTSIZE 18
 
 //TTS Thread
-SDL_Thread *tts_thread;
-int text_to_speech_status;
+extern SDL_Thread *tts_thread;
+extern int text_to_speech_status;
 
 
 extern int debug_status;

--- a/src/t4k_linewrap.c
+++ b/src/t4k_linewrap.c
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include <stdio.h>
 
 static char wrapped_lines0[MAX_LINES][MAX_LINEWIDTH];  // for internal storage
-//char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; // publicly available!
+extern char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; // publicly available!
 
 
 

--- a/src/t4k_menu.c
+++ b/src/t4k_menu.c
@@ -151,7 +151,7 @@ SDL_Surface**   render_buttons(MenuNode* menu, bool selected);
 char*           find_title_length(MenuNode* menu, int* length);
 char*           find_longest_text(MenuNode* menu, int* length);
 int             find_longest_menu_page(MenuNode* menu);
-void            set_font_size();
+void            set_font_size(bool uniform);
 void            prerender_menu(MenuNode* menu);
 int		min(int a, int b);
 int		max(int a, int b);
@@ -383,6 +383,28 @@ void T4K_LoadMenu(int index, const char* file_name)
 
     menus[index] = menu_LoadFile((char *)fn);
 }
+
+void T4K_LoadMenuArbitraryDirectory(int index, const char *directory, const char* file_name)
+{
+    const char* fn = NULL;
+    char temp[T4K_PATH_MAX];
+
+    if(file_name == NULL)
+	return;
+
+    if(menus[index])
+    {
+	free_menu(menus[index]);
+	menus[index] = NULL;
+    }
+
+    snprintf(temp, T4K_PATH_MAX, "%s/%s", directory, file_name);
+    fn = find_file(temp);
+    DEBUGMSG(debug_loaders|debug_menu, "T4K_Loadmenu(): looking in %s\n", fn);
+
+    menus[index] = menu_LoadFile((char *)fn);
+}
+
 
 /* free all loaded menu trees */
 void T4K_UnloadMenus(void)

--- a/src/t4k_menu.c
+++ b/src/t4k_menu.c
@@ -384,26 +384,6 @@ void T4K_LoadMenu(int index, const char* file_name)
     menus[index] = menu_LoadFile((char *)fn);
 }
 
-void T4K_LoadMenuArbitraryDirectory(int index, const char *directory, const char* file_name)
-{
-    const char* fn = NULL;
-    char temp[T4K_PATH_MAX];
-
-    if(file_name == NULL)
-	return;
-
-    if(menus[index])
-    {
-	free_menu(menus[index]);
-	menus[index] = NULL;
-    }
-
-    snprintf(temp, T4K_PATH_MAX, "%s/%s", directory, file_name);
-    fn = find_file(temp);
-    DEBUGMSG(debug_loaders|debug_menu, "T4K_Loadmenu(): looking in %s\n", fn);
-
-    menus[index] = menu_LoadFile((char *)fn);
-}
 
 
 /* free all loaded menu trees */

--- a/src/t4k_menu.c
+++ b/src/t4k_menu.c
@@ -1034,13 +1034,15 @@ int T4K_RunMenu(int index, bool return_choice, void (*draw_background)(), int (*
 			}
 
 			/* Announce the item again when page is scrolled or mouse hover*/
-			if (menu->submenu[loc + menu->first_entry]->desc == NULL)
-				T4K_Tts_say(DEFAULT_VALUE,DEFAULT_VALUE,INTERRUPT,"%s",
-				_(menu->submenu[loc + menu->first_entry]->title));
-			else
-				T4K_Tts_say(DEFAULT_VALUE,DEFAULT_VALUE,INTERRUPT,"%s. %s",
-				_(menu->submenu[loc + menu->first_entry]->title),_(menu->submenu[loc + menu->first_entry]->desc));
-
+		    if(loc >= 0 && loc < items)
+            {
+    			if (menu->submenu[loc + menu->first_entry]->desc == NULL)
+	    			T4K_Tts_say(DEFAULT_VALUE,DEFAULT_VALUE,INTERRUPT,"%s",
+		    		_(menu->submenu[loc + menu->first_entry]->title));
+			    else
+				    T4K_Tts_say(DEFAULT_VALUE,DEFAULT_VALUE,INTERRUPT,"%s. %s",
+    				_(menu->submenu[loc + menu->first_entry]->title),_(menu->submenu[loc + menu->first_entry]->desc));
+            }
 			/* whole menu will be redrawn so there is no need to draw anything now */
 			break;
 		}

--- a/src/t4k_tts.c
+++ b/src/t4k_tts.c
@@ -30,10 +30,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #include "SDL_thread.h"
 
+SDL_Thread *tts_thread;
+int text_to_speech_status;
 
 #if WITH_ESPEAK == 1
 
-#include <speak_lib.h>
+#if WITH_ESPEAK_NG
+# include <espeak-ng/speak_lib.h>
+#else
+# include <speak_lib.h>
+#endif
+
 /* TTS annoncement should be in thread otherwise 
  * it will freez the game till announcemrnt finishes */
 int tts_thread_func(void *arg)
@@ -91,7 +98,6 @@ int T4K_Tts_set_voice(char voice_name[]){
 
 //Stop the speech if it is speaking
 void T4K_Tts_stop(){
-	extern SDL_Thread *tts_thread;
 	if (tts_thread)
 	{
 		SDL_KillThread(tts_thread);
@@ -129,7 +135,6 @@ espeak_SetParameter(espeakPITCH,pitch,0);
  * if mode = APPEND then wait till speaking is finished 
  * then read the new text */
 void T4K_Tts_say(int rate,int pitch,int mode, const char* text, ...){
-	extern SDL_Thread *tts_thread;
 	tts_argument data_to_pass;
 	
 	
@@ -246,7 +251,6 @@ int T4K_Tts_set_voice(char voice_name[]){
 
 //Stop the speech if it is speaking
 void T4K_Tts_stop(){
-	extern SDL_Thread *tts_thread;
 	if (tts_thread)
 	{
 		SDL_KillThread(tts_thread);
@@ -291,7 +295,6 @@ void T4K_Tts_set_pitch(int pitch){
  * if mode = APPEND then wait till speaking is finished 
  * then read the new text */
 void T4K_Tts_say(int rate,int pitch,int mode, const char* text, ...){
-	extern SDL_Thread *tts_thread;
 	tts_argument data_to_pass;
 	
 	


### PR DESCRIPTION
When clicking on penguin's face in tuxtype, a seg_fault is triggered, below gdb's output:


> Thread 1 "tuxtype" received signal SIGSEGV, Segmentation fault.
> 0x00007ffff6ea05a2 in T4K_RunMenu (index=0, return_choice=false, draw_background=0x5555555828a8 <DrawTitleScreen>, handle_event=0x555555582e0f <HandleTitleScreenEvents>, 
>     handle_animations=0x555555583064 <HandleTitleScreenAnimations>, handle_activity=0x555555585427 <handle_activity>) at ../../t4kcommon/src/t4k_menu.c:1058
> 1058				if (menu->submenu[loc + menu->first_entry]->desc == NULL)
> (gdb) by
> Undefined command: "by".  Try "help".
> (gdb) bt
> #0  0x00007ffff6ea05a2 in T4K_RunMenu
>     (index=0, return_choice=false, draw_background=0x5555555828a8 <DrawTitleScreen>, handle_event=0x555555582e0f <HandleTitleScreenEvents>, handle_animations=0x555555583064 <HandleTitleScreenAnimations>, handle_activity=0x555555585427 <handle_activity>) at ../../t4kcommon/src/t4k_menu.c:1058
> #1  0x0000555555585425 in run_menu (which=MENU_MAIN, return_choice=false) at ../../tuxtype_lacki/tuxtype/src/menu.c:82
> #2  0x0000555555585c9e in RunMainMenu () at ../../tuxtype_lacki/tuxtype/src/menu.c:257
> #3  0x00005555555827fd in TitleScreen () at ../../tuxtype_lacki/tuxtype/src/titlescreen.c:316
> #4  0x000055555556abe6 in main (argc=1, argv=0x7fffffffd988) at ../../tuxtype_lacki/tuxtype/src/main.c:219
> (gdb) f 4
> #4  0x000055555556abe6 in main (argc=1, argv=0x7fffffffd988) at ../../tuxtype_lacki/tuxtype/src/main.c:219
> 219	  TitleScreen();
> (gdb) f 0
> #0  0x00007ffff6ea05a2 in T4K_RunMenu (index=0, return_choice=false, draw_background=0x5555555828a8 <DrawTitleScreen>, handle_event=0x555555582e0f <HandleTitleScreenEvents>, 
>     handle_animations=0x555555583064 <HandleTitleScreenAnimations>, handle_activity=0x555555585427 <handle_activity>) at ../../t4kcommon/src/t4k_menu.c:1058
> 1058				if (menu->submenu[loc + menu->first_entry]->desc == NULL)
> 

the problem is in 1058 line in src/t4k_menu.c, where "loc" takes the value -1. as   "menu->first_entry" =0, then we get  "menu->submenu[-1]" and hence segfault. I suggest to add added 
an enclosing if statement to check if loc is >=0  and < items.
This fixes the segfault and allows to show the (easter?) egg as a cursor.




The only change I made is 1058 line in src/t4k_menu.c.  All the remaining changes are from pull request #10   by wjt:  I am not sure if it is possible (I suppose it is) to make pull request on top of someone else's pull request. For sure I have no idea how to do it.