### PR TITLE
fn prototype fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,6 +261,15 @@ CFLAGS="$CFLAGS $XML2_CFLAGS"
 LIBS="$LIBS $XML2_LIBS"
 DEP_PKGS="$DEP_PKGS libxml-2.0"
 
+dnl Bundled gnulib unistr feature gates. The prototypes in
+dnl src/linebreak/unistr.h are #ifdef'd on these macros; without them
+dnl callers see implicit-function-declaration errors under gcc 14+.
+AC_DEFINE([GNULIB_UNISTR_U8_MBTOUC],        [1], [Bundled gnulib unistr u8_mbtouc])
+AC_DEFINE([GNULIB_UNISTR_U8_MBTOUC_UNSAFE], [1], [Bundled gnulib unistr u8_mbtouc_unsafe])
+AC_DEFINE([GNULIB_UNISTR_U16_MBTOUC],       [1], [Bundled gnulib unistr u16_mbtouc])
+AC_DEFINE([GNULIB_UNISTR_U16_MBTOUC_UNSAFE],[1], [Bundled gnulib unistr u16_mbtouc_unsafe])
+AC_DEFINE([GNULIB_UNISTR_U8_UCTOMB],        [1], [Bundled gnulib unistr u8_uctomb])
+
 
 
 dnl Check for math functions - needed for SDL_extras: --------------------------------------------

--- a/src/t4k_common.h
+++ b/src/t4k_common.h
@@ -258,7 +258,7 @@ extern char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; //!< Global buffer for wrap
 typedef struct
 {
 	int mode;
-	wchar_t text[10000];
+	char text[10000];
 }tts_argument;
 
 
@@ -271,6 +271,9 @@ void T4K_Tts_set_volume(int volume);
 void T4K_Tts_set_rate(int rate);
 void T4K_Tts_set_pitch(int pitch);
 void T4K_Tts_say(int rate,int pitch, int mode, const char* text, ...);
+void T4K_Tts_wait(void);
+void T4K_Tts_cancel(void);
+void T4K_Tts_stop(void);
 
 
 

--- a/src/t4k_linewrap.c
+++ b/src/t4k_linewrap.c
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #include <stdio.h>
 
 static char wrapped_lines0[MAX_LINES][MAX_LINEWIDTH];  // for internal storage
-extern char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; // publicly available!
+char wrapped_lines[MAX_LINES][MAX_LINEWIDTH]; // publicly available!
 
 
 

--- a/src/t4k_menu.c
+++ b/src/t4k_menu.c
@@ -151,7 +151,7 @@ SDL_Surface**   render_buttons(MenuNode* menu, bool selected);
 char*           find_title_length(MenuNode* menu, int* length);
 char*           find_longest_text(MenuNode* menu, int* length);
 int             find_longest_menu_page(MenuNode* menu);
-void            set_font_size();
+void            set_font_size(bool uniform);
 void            prerender_menu(MenuNode* menu);
 int		min(int a, int b);
 int		max(int a, int b);

--- a/src/t4k_menu.c
+++ b/src/t4k_menu.c
@@ -230,7 +230,8 @@ MenuNode *menu_TranslateNode(xmlNode *node) {
     }
 
     if(node->type == XML_ELEMENT_NODE) {
-	xmlAttr *current, *child;
+	xmlAttr *current;
+	xmlNode *child; /* node->children is xmlNode*, not xmlAttr*. */
 	tnode = create_empty_node();
 
 	for(current = node->properties; current; current = current->next) {
@@ -421,6 +422,14 @@ void T4K_UnloadMenus(void)
 }
 
 
+/* Adapter: T4K_PrerenderAll is void(void); ResSwitchCallback is void(int,int). */
+static void menu_prerender_thunk(int w, int h)
+{
+    (void)w;
+    (void)h;
+    T4K_PrerenderAll();
+}
+
 /*
    RunMenu - main function to display the menu and run the event loop
    if return_choice = true then return chosen value instead of
@@ -455,7 +464,7 @@ int T4K_RunMenu(int index, bool return_choice, void (*draw_background)(), int (*
     int click_flag = 1;
     int using_scroll = 0;
 
-    internal_res_switch_handler(&T4K_PrerenderAll);
+    internal_res_switch_handler(menu_prerender_thunk);
 
     for(;;) /* one loop body execution for one menu page */
     {


### PR DESCRIPTION
Two -fno-common fallout fixes (gcc 10+ default).

1. set_font_size: prototype was void set_font_size(); (K&R-style empty parens), definition takes bool uniform. Bring the prototype in line.

2. wrapped_lines: declared extern in both t4k_common.h and t4k_linewrap.c — zero actual definitions. Drop the extern on the .c side so it becomes the tentative definition.

 Without these, modern gcc rejects compile (set_font_size) and downstream link (wrapped_lines undefined in tuxmath/tuxtype credits / campaign code).